### PR TITLE
staging

### DIFF
--- a/unpackaged/main/default/objects/a__c/a__c.object-meta.xml
+++ b/unpackaged/main/default/objects/a__c/a__c.object-meta.xml
@@ -153,7 +153,7 @@
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
     <externalSharingModel>Private</externalSharingModel>
-    <label>release</label>
+    <label>accountwhat</label>
     <nameField>
         <label>a Name</label>
         <type>Text</type>


### PR DESCRIPTION
This PR includes a modification to the metadata of the custom object `a__c`. Below is a detailed breakdown of the changes made:

---

## 1. `a__c.object-meta.xml`
**Change:**
- The label for the custom object has been changed from `release` to `accountwhat`.

**Impact:**
- This change alters how the object is referenced in the Salesforce UI and API. The new label `accountwhat` will be displayed in the Salesforce interface wherever this object is referenced. Ensure that any existing documentation, user training materials, or integrations that reference the old label `release` are updated accordingly to avoid confusion.
- Review any existing reports, dashboards, or automation that may rely on the previous label to ensure they function correctly after this change.

---

## Summary
This PR introduces a key update to the custom object `a__c` by changing its label. It is important to verify that all references to this object in the application are updated to reflect the new label and that there are no disruptions in user experience or functionality.